### PR TITLE
Upgrade to ledger-transport 0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ledger-filecoin"
 description = "Library to integrate with the Ledger Filecoin app"
-version = "0.11.0"
+version = "0.12.0"
 license = "Apache-2.0"
 authors = ["Zondax GmbH <info@zondax.ch>"]
 homepage = "https://github.com/ZondaX/ledger-filecoin-rs"
@@ -16,7 +16,8 @@ autobenches = false
 name = "ledger_filecoin"
 
 [dependencies]
-ledger = "0.2.5"
+ledger-transport = "0.9.0"
+ledger-zondax-generic = "0.9.1"
 
 thiserror = "1.0.30"
 
@@ -29,6 +30,10 @@ once_cell = "1.10.0"
 blake2 = "0.10.4"
 k256 = "0.10.4"
 ecdsa = { version = "0.13.4", features = ["verify"] }
+
+tokio = { version = "1", features = ["full"] }
+ledger-transport-hid = "0.9.0"
+serial_test = "0.5.1"
 
 [profile.release]
 overflow-checks = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,10 +20,13 @@
 #![deny(missing_docs)]
 #![doc(html_root_url = "https://docs.rs/ledger-filecoin/0.1.0")]
 
-use ledger::ApduCommand;
+use ledger_transport::{APDUCommand, APDUErrorCode, Exchange};
+use ledger_zondax_generic::{App, AppExt, ChunkPayloadType, Version};
+
+pub use ledger_zondax_generic::LedgerAppError;
 
 mod params;
-use params::{APDUErrors, InstructionCode, PayloadType, CLA, USER_MESSAGE_CHUNK_SIZE};
+use params::{InstructionCode, CLA};
 
 use std::str;
 
@@ -32,42 +35,13 @@ const PK_LEN: usize = 65;
 
 /// Ledger App Error
 #[derive(Debug, thiserror::Error)]
-pub enum Error {
-    /// Invalid version error
-    #[error("This version is not supported")]
-    InvalidVersion,
-
-    /// Invalid path
-    #[error("Invalid path value (bigger than 0x8000_0000)")]
-    InvalidPath,
-
-    /// The message cannot be empty
-    #[error("Message cannot be empty")]
-    InvalidEmptyMessage,
-
-    /// The size fo the message to sign is invalid
-    #[error("message size is invalid (too big)")]
-    InvalidMessageSize,
-
-    /// Public Key is invalid
-    #[error("received an invalid PK")]
-    InvalidPK,
-
-    /// No signature has been returned
-    #[error("received no signature back")]
-    NoSignature,
-
-    /// The signature is not valid
-    #[error("received an invalid signature")]
-    InvalidSignature,
-
-    /// The derivation is invalid
-    #[error("invalid derivation path")]
-    InvalidDerivationPath,
-
-    /// Device related errors
-    #[error("Ledger error: {0}")]
-    Ledger(#[from] ledger::Error),
+pub enum FilError<E>
+where
+    E: std::error::Error,
+{
+    #[error("Ledger | {0}")]
+    /// Common Ledger errors
+    Ledger(#[from] LedgerAppError<E>),
 
     /// Device related errors
     #[error("Secp256k1 error: {0}")]
@@ -76,18 +50,16 @@ pub enum Error {
     /// Device related errors
     #[error("Ecdsa error: {0}")]
     Ecdsa(#[from] k256::ecdsa::Error),
-
-    /// Utf8 conversion related error
-    #[error("UTF8Error error: {0}")]
-    Utf8(#[from] std::str::Utf8Error),
 }
 
 /// Filecoin App
-pub struct FilecoinApp {
-    app: ledger::LedgerApp,
+pub struct FilecoinApp<E> {
+    apdu_transport: E,
 }
 
-unsafe impl Send for FilecoinApp {}
+impl<E: Exchange> App for FilecoinApp<E> {
+    const CLA: u8 = CLA;
+}
 
 /// FilecoinApp address (includes pubkey and the corresponding ss58 address)
 pub struct Address {
@@ -116,18 +88,6 @@ pub struct Signature {
     pub sig: k256::ecdsa::Signature,
 }
 
-/// FilecoinApp App Version
-pub struct Version {
-    /// Application Mode
-    pub mode: u8,
-    /// Version Major
-    pub major: u8,
-    /// Version Minor
-    pub minor: u8,
-    /// Version Patch
-    pub patch: u8,
-}
-
 /// BIP44 Path
 pub struct BIP44Path {
     /// Purpose
@@ -142,162 +102,152 @@ pub struct BIP44Path {
     pub index: u32,
 }
 
-fn serialize_bip44(path: &BIP44Path) -> Result<Vec<u8>, Error> {
-    use byteorder::{LittleEndian, WriteBytesExt};
-    let mut m = Vec::new();
+impl BIP44Path {
+    /// Serialize a [`BIP44Path`] in the format used in the app
+    pub fn serialize_bip44(&self) -> Vec<u8> {
+        use byteorder::{LittleEndian, WriteBytesExt};
+        let mut m = Vec::new();
 
-    m.write_u32::<LittleEndian>(path.purpose).unwrap();
-    m.write_u32::<LittleEndian>(path.coin).unwrap();
-    m.write_u32::<LittleEndian>(path.account).unwrap();
-    m.write_u32::<LittleEndian>(path.change).unwrap();
-    m.write_u32::<LittleEndian>(path.index).unwrap();
+        m.write_u32::<LittleEndian>(self.purpose).unwrap();
+        m.write_u32::<LittleEndian>(self.coin).unwrap();
+        m.write_u32::<LittleEndian>(self.account).unwrap();
+        m.write_u32::<LittleEndian>(self.change).unwrap();
+        m.write_u32::<LittleEndian>(self.index).unwrap();
 
-    Ok(m)
+        m
+    }
 }
 
-impl FilecoinApp {
-    /// Connect to the Ledger App
-    pub fn connect() -> Result<Self, Error> {
-        let app = ledger::LedgerApp::new()?;
-        Ok(FilecoinApp { app })
+impl<E> FilecoinApp<E> {
+    /// Create a new [`FilecoinApp`] with the given transport
+    pub const fn new(transport: E) -> Self {
+        FilecoinApp {
+            apdu_transport: transport,
+        }
     }
+}
 
+impl<E> FilecoinApp<E>
+where
+    E: Exchange + Send + Sync,
+    E::Error: std::error::Error,
+{
     /// Retrieve the app version
-    pub fn version(&self) -> Result<Version, Error> {
-        let command = ApduCommand {
-            cla: CLA,
-            ins: InstructionCode::GetVersion as _,
-            p1: 0x00,
-            p2: 0x00,
-            length: 0,
-            data: Vec::new(),
-        };
-
-        let response = self.app.exchange(command)?;
-        if response.retcode != APDUErrors::NoError as u16 {
-            return Err(Error::InvalidVersion);
-        }
-
-        if response.data.len() < 4 {
-            return Err(Error::InvalidVersion);
-        }
-
-        let version = Version {
-            mode: response.data[0],
-            major: response.data[1],
-            minor: response.data[2],
-            patch: response.data[3],
-        };
-
-        Ok(version)
+    pub async fn version(&self) -> Result<Version, FilError<E::Error>> {
+        <Self as AppExt<E>>::get_version(&self.apdu_transport)
+            .await
+            .map_err(Into::into)
     }
 
     /// Retrieves the public key and address
-    pub fn address(&self, path: &BIP44Path, require_confirmation: bool) -> Result<Address, Error> {
-        let serialized_path = serialize_bip44(path)?;
+    pub async fn address(
+        &self,
+        path: &BIP44Path,
+        require_confirmation: bool,
+    ) -> Result<Address, FilError<E::Error>> {
+        let serialized_path = path.serialize_bip44();
         let p1 = if require_confirmation { 1 } else { 0 };
 
-        let command = ApduCommand {
+        let command = APDUCommand {
             cla: CLA,
             ins: InstructionCode::GetAddrSecp256k1 as _,
             p1,
             p2: 0x00,
-            length: 0,
             data: serialized_path,
         };
 
-        match self.app.exchange(command) {
-            Ok(response) => {
-                if response.retcode != APDUErrors::NoError as u16 {
-                    println!("WARNING: retcode={:X?}", response.retcode);
-                }
+        let response = self
+            .apdu_transport
+            .exchange(&command)
+            .await
+            .map_err(LedgerAppError::TransportError)?;
 
-                if response.data.len() < PK_LEN {
-                    return Err(Error::InvalidPK);
-                }
-
-                let public_key = k256::PublicKey::from_sec1_bytes(&response.data[..PK_LEN])?;
-                let mut addr_byte = [Default::default(); 21];
-                addr_byte.copy_from_slice(&response.data[PK_LEN + 1..PK_LEN + 1 + 21]);
-                let tmp = str::from_utf8(&response.data[PK_LEN + 2 + 21..])?;
-                let addr_string = tmp.to_owned();
-
-                let address = Address {
-                    public_key,
-                    addr_byte,
-                    addr_string,
-                };
-                Ok(address)
+        let response_data = response.data();
+        match response.error_code() {
+            Ok(APDUErrorCode::NoError) if response_data.len() < PK_LEN => {
+                return Err(FilError::Ledger(LedgerAppError::InvalidPK))
             }
-            Err(err) => Err(Error::Ledger(err)),
+            Ok(APDUErrorCode::NoError) => {}
+            Ok(err) => {
+                return Err(FilError::Ledger(LedgerAppError::AppSpecific(
+                    err as _,
+                    err.description(),
+                )))
+            }
+            Err(err) => {
+                return Err(FilError::Ledger(LedgerAppError::AppSpecific(
+                    err,
+                    "[APDU_ERROR] Unknown".to_string(),
+                )))
+            }
         }
+
+        let public_key = k256::PublicKey::from_sec1_bytes(&response_data[..PK_LEN])?;
+        let mut addr_byte = [Default::default(); 21];
+        addr_byte.copy_from_slice(&response_data[PK_LEN + 1..PK_LEN + 1 + 21]);
+        let tmp =
+            str::from_utf8(&response_data[PK_LEN + 2 + 21..]).map_err(|_| LedgerAppError::Utf8)?;
+        let addr_string = tmp.to_owned();
+
+        Ok(Address {
+            public_key,
+            addr_byte,
+            addr_string,
+        })
     }
 
     /// Sign a transaction
-    pub fn sign(&self, path: &BIP44Path, message: &[u8]) -> Result<Signature, Error> {
-        let bip44path = serialize_bip44(path)?;
-        let chunks = message.chunks(USER_MESSAGE_CHUNK_SIZE);
+    pub async fn sign(
+        &self,
+        path: &BIP44Path,
+        message: &[u8],
+    ) -> Result<Signature, FilError<E::Error>> {
+        let bip44path = path.serialize_bip44();
 
-        if chunks.len() > 255 {
-            return Err(Error::InvalidMessageSize);
-        }
-
-        if chunks.len() == 0 {
-            return Err(Error::InvalidEmptyMessage);
-        }
-
-        let packet_count = chunks.len() as u8;
-
-        let _command = ApduCommand {
+        let start_command = APDUCommand {
             cla: CLA,
             ins: InstructionCode::SignSecp256k1 as _,
-            p1: PayloadType::Init as u8,
+            p1: ChunkPayloadType::Init as u8,
             p2: 0x00,
-            length: bip44path.len() as u8,
             data: bip44path,
         };
 
-        let mut response = self.app.exchange(_command)?;
+        let response =
+            <Self as AppExt<E>>::send_chunks(&self.apdu_transport, start_command, message).await?;
 
-        // Send message chunks
-        for (packet_idx, chunk) in chunks.enumerate() {
-            let mut p1 = PayloadType::Add as u8;
-            if packet_idx == (packet_count - 1) as usize {
-                p1 = PayloadType::Last as u8
+        let response_data = response.data();
+        match response.error_code() {
+            Ok(APDUErrorCode::NoError) if response_data.is_empty() => {
+                return Err(FilError::Ledger(LedgerAppError::NoSignature))
             }
-
-            let _command = ApduCommand {
-                cla: CLA,
-                ins: InstructionCode::SignSecp256k1 as _,
-                p1,
-                p2: 0,
-                length: chunk.len() as u8,
-                data: chunk.to_vec(),
-            };
-
-            response = self.app.exchange(_command)?;
+            // Last response should contain the answer
+            Ok(APDUErrorCode::NoError) if response_data.len() < 3 => {
+                return Err(FilError::Ledger(LedgerAppError::InvalidSignature))
+            }
+            Ok(APDUErrorCode::NoError) => {}
+            Ok(err) => {
+                return Err(FilError::Ledger(LedgerAppError::AppSpecific(
+                    err as _,
+                    err.description(),
+                )))
+            }
+            Err(err) => {
+                return Err(FilError::Ledger(LedgerAppError::AppSpecific(
+                    err,
+                    "[APDU_ERROR] Unknown".to_string(),
+                )))
+            }
         }
 
-        if response.data.is_empty() && response.retcode == APDUErrors::NoError as u16 {
-            return Err(Error::NoSignature);
-        }
+        let mut r = [0; 32];
+        r.copy_from_slice(&response_data[..32]);
 
-        // Last response should contain the answer
-        if response.data.len() < 3 {
-            return Err(Error::InvalidSignature);
-        }
+        let mut s = [0; 32];
+        s.copy_from_slice(&response_data[32..64]);
 
-        //let sig_buffer_len = response.data.len();
+        let v = response_data[64];
 
-        let mut r = [Default::default(); 32];
-        r.copy_from_slice(&response.data[..32]);
-
-        let mut s = [Default::default(); 32];
-        s.copy_from_slice(&response.data[32..64]);
-
-        let v = response.data[64];
-
-        let sig = k256::ecdsa::Signature::from_der(&response.data[65..])?;
+        let sig = k256::ecdsa::Signature::from_der(&response_data[65..])?;
 
         let signature = Signature { r, s, v, sig };
 
@@ -307,7 +257,7 @@ impl FilecoinApp {
 
 #[cfg(test)]
 mod tests {
-    use crate::{serialize_bip44, BIP44Path};
+    use super::BIP44Path;
 
     #[test]
     fn bip44() {
@@ -318,7 +268,7 @@ mod tests {
             change: 0,
             index: 0x5678,
         };
-        let serialized_path = serialize_bip44(&path).unwrap();
+        let serialized_path = path.serialize_bip44();
         assert_eq!(serialized_path.len(), 20);
         assert_eq!(
             hex::encode(&serialized_path),

--- a/src/params.rs
+++ b/src/params.rs
@@ -21,19 +21,6 @@ pub const CLA: u8 = 0x06;
 
 #[repr(u8)]
 pub enum InstructionCode {
-    GetVersion = 0,
     GetAddrSecp256k1 = 1,
     SignSecp256k1 = 2,
-}
-
-pub const USER_MESSAGE_CHUNK_SIZE: usize = 250;
-
-pub enum PayloadType {
-    Init = 0x00,
-    Add = 0x01,
-    Last = 0x02,
-}
-
-pub enum APDUErrors {
-    NoError = 0x9000,
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -21,138 +21,112 @@
 
 extern crate ledger_filecoin;
 
-use std::sync::Mutex;
-
 use blake2::{digest::typenum, Blake2b, Digest};
 use ecdsa::{signature::Verifier, VerifyingKey};
 use k256::{elliptic_curve::sec1::ToEncodedPoint, Secp256k1};
 
-use ledger_filecoin::{BIP44Path, Error, FilecoinApp};
+use ledger_filecoin::{BIP44Path, FilError, FilecoinApp, LedgerAppError};
+use ledger_transport_hid::{hidapi::HidApi, TransportNativeHID};
 
 use once_cell::sync::Lazy;
+use serial_test::serial;
 
-static APP: Lazy<Mutex<FilecoinApp>> = Lazy::new(|| Mutex::new(FilecoinApp::connect().unwrap()));
+static HIDAPI: Lazy<HidApi> = Lazy::new(|| HidApi::new().expect("Failed to create Hidapi"));
 
 type Blake2b256 = Blake2b<typenum::U32>;
 
-#[test]
-fn version() {
-    let mut error_detected = false;
-    {
-        let app = APP.lock().unwrap();
-
-        let resp = app.version();
-
-        match resp {
-            Ok(version) => {
-                println!("mode  {}", version.mode);
-                println!("major {}", version.major);
-                println!("minor {}", version.minor);
-                println!("patch {}", version.patch);
-
-                assert_eq!(version.major, 0x00);
-                assert!(version.minor >= 0x12);
-            }
-            Err(err) => {
-                eprintln!("Error: {:?}", err);
-                error_detected = true;
-            }
-        }
-    }
-    assert!(!error_detected);
+fn app() -> FilecoinApp<TransportNativeHID> {
+    FilecoinApp::new(TransportNativeHID::new(&HIDAPI).expect("unable to create transport"))
 }
 
-#[test]
-fn address() {
-    let mut error_detected = false;
-    {
-        let app = APP.lock().unwrap();
-        let path = BIP44Path {
-            purpose: 0x8000_0000 | 44,
-            coin: 0x8000_0000 | 461,
-            account: 0,
-            change: 0,
-            index: 0,
-        };
-        let resp = app.address(&path, false);
+#[tokio::test]
+#[serial]
+async fn version() {
+    let app = app();
 
-        match resp {
-            Ok(addr) => {
-                let public_key_bytes = addr.public_key.to_encoded_point(true);
+    let version = app.version().await.unwrap();
 
-                assert_eq!(
-                    hex::encode(&public_key_bytes),
-                    "0235e752dc6b4113f78edcf2cf7b8082e442021de5f00818f555397a6f181af795"
-                );
-                assert_eq!(
-                    hex::encode(&addr.addr_byte),
-                    "011eaf1c8a4bbfeeb0870b1745b1f57503470b7116"
-                );
-                assert_eq!(
-                    addr.addr_string,
-                    "f1d2xrzcslx7xlbbylc5c3d5lvandqw4iwl6epxba"
-                );
+    println!("mode  {}", version.mode);
+    println!("major {}", version.major);
+    println!("minor {}", version.minor);
+    println!("patch {}", version.patch);
 
-                println!("Public Key  {:?}", hex::encode(&public_key_bytes));
-                println!("Address Byte Format  {:?}", hex::encode(&addr.addr_byte));
-                println!("Address String Format  {:?}", addr.addr_string);
-            }
-            Err(err) => {
-                eprintln!("Error: {:?}", err);
-                error_detected = true;
-            }
-        }
-    }
-    assert!(!error_detected);
+    assert_eq!(version.major, 0x00);
+    assert!(version.minor >= 0x12);
 }
 
-#[test]
-fn address_testnet() {
-    let mut error_detected = false;
-    {
-        let app = APP.lock().unwrap();
-        let path = BIP44Path {
-            purpose: 0x8000_0000 | 44,
-            coin: 0x8000_0000 | 1,
-            account: 0,
-            change: 0,
-            index: 0,
-        };
-        let resp = app.address(&path, false);
+#[tokio::test]
+#[serial]
+async fn address() {
+    let app = app();
+    let path = BIP44Path {
+        purpose: 0x8000_0000 | 44,
+        coin: 0x8000_0000 | 461,
+        account: 0,
+        change: 0,
+        index: 0,
+    };
 
-        match resp {
-            Ok(addr) => {
-                let public_key_bytes = addr.public_key.to_encoded_point(true);
+    let addr = app.address(&path, false).await.unwrap();
 
-                assert_eq!(
-                    hex::encode(&public_key_bytes),
-                    "0266f2bdb19e90fd7c29e4bf63612eb98515e5163c97888042364ba777d818e88b"
-                );
-                assert_eq!(
-                    hex::encode(&addr.addr_byte),
-                    "01dfe49184d46adc8f89d44638beb45f78fcad2590"
-                );
-                assert_eq!(
-                    addr.addr_string,
-                    "t137sjdbgunloi7couiy4l5nc7pd6k2jmq32vizpy"
-                );
+    let public_key_bytes = addr.public_key.to_encoded_point(true);
 
-                println!("Public Key  {:?}", hex::encode(&public_key_bytes));
-                println!("Address Byte Format  {:?}", hex::encode(&addr.addr_byte));
-                println!("Address String Format  {:?}", addr.addr_string);
-            }
-            Err(err) => {
-                eprintln!("Error: {:?}", err);
-                error_detected = true;
-            }
-        }
-    }
-    assert!(!error_detected);
+    assert_eq!(
+        hex::encode(&public_key_bytes),
+        "0235e752dc6b4113f78edcf2cf7b8082e442021de5f00818f555397a6f181af795"
+    );
+    assert_eq!(
+        hex::encode(&addr.addr_byte),
+        "011eaf1c8a4bbfeeb0870b1745b1f57503470b7116"
+    );
+    assert_eq!(
+        addr.addr_string,
+        "f1d2xrzcslx7xlbbylc5c3d5lvandqw4iwl6epxba"
+    );
+
+    println!("Public Key  {:?}", hex::encode(&public_key_bytes));
+    println!("Address Byte Format  {:?}", hex::encode(&addr.addr_byte));
+    println!("Address String Format  {:?}", addr.addr_string);
 }
 
-#[test]
-fn sign_empty() {
-    let app = APP.lock().unwrap();
+#[tokio::test]
+#[serial]
+async fn address_testnet() {
+    let app = app();
+    let path = BIP44Path {
+        purpose: 0x8000_0000 | 44,
+        coin: 0x8000_0000 | 1,
+        account: 0,
+        change: 0,
+        index: 0,
+    };
+
+    let addr = app.address(&path, false).await.unwrap();
+
+    let public_key_bytes = addr.public_key.to_encoded_point(true);
+
+    assert_eq!(
+        hex::encode(&public_key_bytes),
+        "0266f2bdb19e90fd7c29e4bf63612eb98515e5163c97888042364ba777d818e88b"
+    );
+    assert_eq!(
+        hex::encode(&addr.addr_byte),
+        "01dfe49184d46adc8f89d44638beb45f78fcad2590"
+    );
+    assert_eq!(
+        addr.addr_string,
+        "t137sjdbgunloi7couiy4l5nc7pd6k2jmq32vizpy"
+    );
+
+    println!("Public Key  {:?}", hex::encode(&public_key_bytes));
+    println!("Address Byte Format  {:?}", hex::encode(&addr.addr_byte));
+    println!("Address String Format  {:?}", addr.addr_string);
+}
+
+#[tokio::test]
+#[serial]
+async fn sign_empty() {
+    let app = app();
 
     let path = BIP44Path {
         purpose: 0x8000_0000 | 44,
@@ -162,63 +136,53 @@ fn sign_empty() {
         index: 0,
     };
     let some_message0 = b"";
-    let signature = app.sign(&path, some_message0);
+    let signature = app.sign(&path, some_message0).await;
     assert!(signature.is_err());
     assert!(matches!(
         signature.err().unwrap(),
-        Error::InvalidEmptyMessage
+        FilError::Ledger(LedgerAppError::InvalidEmptyMessage)
     ));
 }
 
-#[test]
-fn sign_verify() {
-    let mut error_detected = false;
-    {
-        let app = APP.lock().unwrap();
+#[tokio::test]
+#[serial]
+async fn sign_verify() {
+    let app = app();
 
-        let txstr = "8a0058310396a1a3e4ea7a14d49985e661b22401d44fed402d1d0925b243c923589c0fbc7e32cd04e29ed78d15d37d3aaa3fe6da3358310386b454258c589475f7d16f5aac018a79f6c1169d20fc33921dd8b5ce1cac6c348f90a3603624f6aeb91b64518c2e80950144000186a01961a8430009c44200000040";
-        let blob = hex::decode(txstr).unwrap();
+    let txstr = "8a0058310396a1a3e4ea7a14d49985e661b22401d44fed402d1d0925b243c923589c0fbc7e32cd04e29ed78d15d37d3aaa3fe6da3358310386b454258c589475f7d16f5aac018a79f6c1169d20fc33921dd8b5ce1cac6c348f90a3603624f6aeb91b64518c2e80950144000186a01961a8430009c44200000040";
+    let blob = hex::decode(txstr).unwrap();
 
-        let path = BIP44Path {
-            purpose: 0x8000_0000 | 44,
-            coin: 0x8000_0000 | 461,
-            account: 0,
-            change: 0,
-            index: 0,
-        };
-        match app.sign(&path, &blob) {
-            Ok(signature) => {
-                println!("{:#?}", hex::encode(&signature.sig.to_vec()));
+    let path = BIP44Path {
+        purpose: 0x8000_0000 | 44,
+        coin: 0x8000_0000 | 461,
+        account: 0,
+        change: 0,
+        index: 0,
+    };
 
-                // First, get public key
-                let addr = app.address(&path, false).unwrap();
+    // First, get public key
+    let addr = app.address(&path, false).await.unwrap();
 
-                let mut blake2b = Blake2b256::new();
-                blake2b.update(&blob);
+    let signature = app.sign(&path, &blob).await.unwrap();
+    println!("{:#?}", hex::encode(&signature.sig.to_vec()));
 
-                let message_hashed = blake2b.finalize_reset();
-                println!("Message hashed {}", hex::encode(&message_hashed));
+    let mut blake2b = Blake2b256::new();
+    blake2b.update(&blob);
 
-                let cid = hex::decode("0171a0e40220").unwrap();
-                blake2b.update(&cid);
-                blake2b.update(&message_hashed);
+    let message_hashed = blake2b.finalize_reset();
+    println!("Message hashed {}", hex::encode(&message_hashed));
 
-                let cid_hashed = blake2b.clone().finalize();
-                println!("Cid hashed {}", hex::encode(&cid_hashed));
+    let cid = hex::decode("0171a0e40220").unwrap();
+    blake2b.update(&cid);
+    blake2b.update(&message_hashed);
 
-                let verifying_key = VerifyingKey::<Secp256k1>::from_encoded_point(
-                    &addr.public_key.to_encoded_point(true),
-                )
-                .unwrap();
-                assert!(verifying_key
-                    .verify(&blake2b.finalize(), &signature.sig)
-                    .is_ok())
-            }
-            Err(e) => {
-                println!("Err {:#?}", e);
-                error_detected = true;
-            }
-        }
-    }
-    assert!(!error_detected);
+    let cid_hashed = blake2b.clone().finalize();
+    println!("Cid hashed {}", hex::encode(&cid_hashed));
+
+    let verifying_key =
+        VerifyingKey::<Secp256k1>::from_encoded_point(&addr.public_key.to_encoded_point(true))
+            .unwrap();
+    assert!(verifying_key
+        .verify(&blake2b.finalize(), &signature.sig)
+        .is_ok())
 }


### PR DESCRIPTION
This PR upgrade to `ledger-transport` v0.9.0 and refactors the API for it.

The version is bumped already.

<!-- ClickUpRef: 29wj7c9 -->