### PR TITLE
Update k256 Crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ ledger-zondax-generic = "0.9.1"
 thiserror = "1.0.30"
 
 byteorder = "1.4.3"
-k256 = { version = "0.10.4", features = ["ecdsa-core", "arithmetic", "std"], default-features = false }
+k256 = { version = "^13.0", features = ["ecdsa-core", "arithmetic", "std"], default-features = false }
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,13 +22,13 @@ ledger-zondax-generic = "0.9.1"
 thiserror = "1.0.30"
 
 byteorder = "1.4.3"
-k256 = { version = "^13.0", features = ["ecdsa-core", "arithmetic", "std"], default-features = false }
+k256 = { version = "^0.11", features = ["ecdsa-core", "arithmetic", "std"], default-features = false }
 
 [dev-dependencies]
 hex = "0.4.3"
 once_cell = "1.10.0"
 blake2 = "0.10.4"
-k256 = "0.10.4"
+k256 = "^0.11"
 ecdsa = { version = "0.13.4", features = ["verify"] }
 
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
## Description

The k256 crate version is fixed and causes dependency conflicts when building with other crates such as `ehters-rs`. Given that this crate is highly likely to be used alongside ethers, makes sense to update the k256 version to resolve those conflicts. 

<!-- ClickUpRef: 867804urb -->
:link: [zboto Link](https://app.clickup.com/t/867804urb)