### PR TITLE
Remove deprecated functionality in Github Action

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,7 +9,6 @@ jobs:
       uid_gid: ${{ steps.get-user.outputs.uid_gid }}
     steps:
       - id: get-user
-        run: echo "::set-output name=uid_gid::$(id -u):$(id -g)"
         run: echo "uid_gid=$(id -u):$(id -g)" >> $GITHUB_OUTPUT
 
   lint:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -30,7 +30,7 @@ jobs:
           cargo fmt -- --check
 
       - name: rust cache
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
         with:
           # setup sharedKey to share cache with other jobs
           sharedKey: ${{ github.run_id }}-${{ github.run_attempt }}
@@ -51,7 +51,7 @@ jobs:
           submodules: true
 
       - name: Rust Dependency Cache
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
         with:
           # setup sharedKey to share cache with other jobs
           sharedKey: ${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,6 +10,7 @@ jobs:
     steps:
       - id: get-user
         run: echo "::set-output name=uid_gid::$(id -u):$(id -g)"
+        run: echo "uid_gid=$(id -u):$(id -g)" >> $GITHUB_OUTPUT
 
   lint:
     runs-on: ubuntu-latest
@@ -17,7 +18,7 @@ jobs:
       image: zondax/rust-ci:latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: true
       - run: sudo apt-get install -y libudev-dev libusb-1.0-0-dev
@@ -46,7 +47,7 @@ jobs:
       image: zondax/rust-ci:latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: true
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -32,8 +32,8 @@ jobs:
       - name: rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          # setup sharedKey to share cache with other jobs
-          sharedKey: ${{ github.run_id }}-${{ github.run_attempt }}
+          # setup shared-key to share cache with other jobs
+          shared-key: ${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: clippy
         run: |
@@ -53,8 +53,8 @@ jobs:
       - name: Rust Dependency Cache
         uses: Swatinem/rust-cache@v2
         with:
-          # setup sharedKey to share cache with other jobs
-          sharedKey: ${{ github.run_id }}-${{ github.run_attempt }}
+          # setup shared-key to share cache with other jobs
+          shared-key: ${{ github.run_id }}-${{ github.run_attempt }}
 
       - run: sudo apt-get install -y libudev-dev libusb-1.0.0-dev
       - name: test --all-features

--- a/.github/workflows/rust_audit.yaml
+++ b/.github/workflows/rust_audit.yaml
@@ -10,7 +10,7 @@ jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: true
 

--- a/.github/workflows/rust_periodic_audit.yaml
+++ b/.github/workflows/rust_periodic_audit.yaml
@@ -9,7 +9,7 @@ jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,14 @@ ledger-zondax-generic = "0.9.1"
 thiserror = "1.0.30"
 
 byteorder = "1.4.3"
-k256 = { version = "^0.11", features = ["ecdsa-core", "arithmetic", "std"], default-features = false }
+k256 = { version = "^0.13", features = ["ecdsa-core", "arithmetic", "std"], default-features = false }
 
 [dev-dependencies]
 hex = "0.4.3"
 once_cell = "1.10.0"
 blake2 = "0.10.4"
-k256 = "^0.11"
-ecdsa = { version = "0.13.4", features = ["verify"] }
+k256 = "^0.13"
+ecdsa = { version = "0.16.9", features = ["verifying"] }
 
 tokio = { version = "1", features = ["full"] }
 ledger-transport-hid = "0.9.0"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Rust library for Ledger Filecoin app
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![CircleCI](https://circleci.com/gh/Zondax/ledger-filecoin-rs.svg?style=shield&circle-token=a4812682fd7a221a0fc196f0889f5b8d76b1a46d)](https://circleci.com/gh/Zondax/ledger-filecoin-rs)
 
 This package provides a basic Rust client library to communicate with the Filecoin App running in a Ledger Nano S/X devices
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -22,7 +22,7 @@
 extern crate ledger_filecoin;
 
 use blake2::{digest::typenum, Blake2b, Digest};
-use ecdsa::{signature::Verifier, VerifyingKey};
+use ecdsa::{VerifyingKey, signature::Verifier};
 use k256::{elliptic_curve::sec1::ToEncodedPoint, Secp256k1};
 
 use ledger_filecoin::{BIP44Path, FilError, FilecoinApp, LedgerAppError};

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -22,7 +22,7 @@
 extern crate ledger_filecoin;
 
 use blake2::{digest::typenum, Blake2b, Digest};
-use ecdsa::{VerifyingKey, signature::Verifier};
+use ecdsa::{signature::Verifier, VerifyingKey};
 use k256::{elliptic_curve::sec1::ToEncodedPoint, Secp256k1};
 
 use ledger_filecoin::{BIP44Path, FilError, FilecoinApp, LedgerAppError};


### PR DESCRIPTION
This PR transaction from `set-outputs` deprecated use to the new[ Github Environement](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) way of doing. It remove the deprecated mention of Circle CI and it upgrades `actions/checkout` from V2 to V4.

Also fix the dependencies conflict by upgrading some libraries.

<!-- ClickUpRef: 8694wm3a2 -->
:link: [zboto Link](https://app.clickup.com/t/8694wm3a2)